### PR TITLE
fixed issue #7 (coupling graph)

### DIFF
--- a/backends/ibmqx3/README.md
+++ b/backends/ibmqx3/README.md
@@ -12,7 +12,7 @@ This device went online June 2017.
 
 The connectivity map for the CNOTS in this device is
 ```
-coupling_map = {0:[1], 1: [2], 2: [3], 3: [14], 4: [3, 5], 6: [7, 11], 7: [10], 8: [7], 9: [8, 10], 11: [10], 12: [5, 11, 13], 13: [4, 14], 15: [0, 14]}
+coupling_map = {1:[0,2], 2:[3], 3:[4, 14], 5:[4], 6:[5,7,11], 7:[10], 8:[7],9:[8, 10], 11:[10], 12:[5, 11, 13], 13:[4, 14], 15:[0, 2, 14]}
 ```
 Where a: [b] means a CNOT with qubit a as control and b as target can be implemented.
 

--- a/backends/ibmqx3/README.md
+++ b/backends/ibmqx3/README.md
@@ -12,7 +12,7 @@ This device went online June 2017.
 
 The connectivity map for the CNOTS in this device is
 ```
-coupling_map = {1:[0,2], 2:[3], 3:[4, 14], 5:[4], 6:[5,7,11], 7:[10], 8:[7],9:[8, 10], 11:[10], 12:[5, 11, 13], 13:[4, 14], 15:[0, 2, 14]}
+coupling_map = {0:[1], 1: [2], 2: [3], 3: [14], 4: [3, 5], 6: [7, 11], 7: [10], 8: [7], 9: [8, 10], 11: [10], 12: [5, 11, 13], 13: [4, 14], 15: [0, 14]}
 ```
 Where a: [b] means a CNOT with qubit a as control and b as target can be implemented.
 

--- a/backends/ibmqx5/README.md
+++ b/backends/ibmqx5/README.md
@@ -16,7 +16,7 @@ This device went online 09/28/2017.
 
 The connectivity map for the CNOTS in this device is
 ```
-coupling_map = {1:[2], 2:[3], 3:[4, 14], 5:[4], 6:[7], 6:[11], 7:[10], 8:[7], 9:[8, 10], 11:[10], 12:[5, 11, 13], 13:[4, 14], 15:[0, 2, 14]}
+coupling_map = {1:[0,2], 2:[3], 3:[4, 14], 5:[4], 6:[5,7,11], 7:[10], 8:[7],9:[8, 10], 11:[10], 12:[5, 11, 13], 13:[4, 14], 15:[0, 2, 14]}
 ```
 Where a: [b] means a CNOT with qubit a as control and b as target can be implemented.
 


### PR DESCRIPTION
ibmqx3 and ibmqx5 are now consistent with the coupling map on the QX website